### PR TITLE
Sites are now deleted logically. Added API query parameter "delete_since" to get deleted sites since a particular time.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.6'
-gem 'mysql2'
+gem 'mysql2', '~> 0.3.17'
 gem 'devise'
 gem 'haml-rails', '~> 0.4'
 gem 'gettext', '~> 3.1.2'
@@ -37,6 +37,7 @@ gem 'active_model_serializers'
 gem 'includes-count'
 gem 'poirot_rails', git: "https://github.com/instedd/poirot_rails.git", branch: 'master' unless ENV['CI']
 gem 'instedd_telemetry', git: "https://github.com/instedd/telemetry_rails", branch: 'master'
+gem 'paranoia', '~> 2.0'
 
 gem 'treetop', '1.4.15'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
     msgpack (0.6.0)
     multi_json (1.10.1)
     multipart-post (2.0.0)
-    mysql2 (0.3.16)
+    mysql2 (0.3.20)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -291,6 +291,8 @@ GEM
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
     orm_adapter (0.5.0)
+    paranoia (2.1.5)
+      activerecord (~> 4.0)
     po_to_json (0.0.7)
       json
     polyglot (0.3.5)
@@ -500,13 +502,14 @@ DEPENDENCIES
   machinist (= 1.0.6)
   mini_magick
   msgpack
-  mysql2
+  mysql2 (~> 0.3.17)
   newrelic_rpm
   nokogiri
   nuntium_api (~> 0.13)
   oj
   omniauth
   omniauth-openid
+  paranoia (~> 2.0)
   poirot_rails!
   protected_attributes
   pry-byebug
@@ -534,3 +537,6 @@ DEPENDENCIES
   uglifier (>= 2.5.0)
   uuidtools
   will_paginate
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/api/collections_controller.rb
+++ b/app/controllers/api/collections_controller.rb
@@ -122,7 +122,7 @@ class Api::CollectionsController < ApiController
   end
 
   def build_search(*options)
-    except_params = [:action, :controller, :format, :id, :site_id, :updated_since, :search, :box, :lat, :lng, :radius, :fields, :name, :sitename, :page_size, :location_missing, :locale, :human]
+    except_params = [:action, :controller, :format, :id, :site_id, :updated_since, :deleted_since, :search, :box, :lat, :lng, :radius, :fields, :name, :sitename, :page_size, :location_missing, :locale, :human]
 
     # cache all fields to accelerate condition building
     collection.fields.each {|field| field.cache_for_read}
@@ -148,6 +148,7 @@ class Api::CollectionsController < ApiController
 
     search.id(params[:site_id]) if params[:site_id]
     search.after params[:updated_since] if params[:updated_since]
+    search.deleted_since params[:deleted_since] if params[:deleted_since]
     search.full_text_search params[:search] if params[:search]
     search.box *valid_box_coordinates if params[:box]
     search.select_fields(params[:fields]) if params[:fields]

--- a/app/helpers/api/json_helper.rb
+++ b/app/helpers/api/json_helper.rb
@@ -21,6 +21,10 @@ module Api::JsonHelper
     obj[:createdAt] = Site.parse_time(source['created_at'])
     obj[:updatedAt] = Site.parse_time(source['updated_at'])
 
+    if source['deleted_at']
+      obj[:deletedAt] = Site.parse_time(source['deleted_at'])
+    end
+
     if source['location']
       obj[:lat] = source['location']['lat']
       obj[:long] = source['location']['lon']

--- a/app/models/collection/elasticsearch_concern.rb
+++ b/app/models/collection/elasticsearch_concern.rb
@@ -44,7 +44,7 @@ module Collection::ElasticsearchConcern
 
     client = Elasticsearch::Client.new
 
-    docs = sites.map do |site|
+    docs = sites.with_deleted.map do |site|
       site.collection = self
       site.to_elastic_search
     end

--- a/app/models/history_concern.rb
+++ b/app/models/history_concern.rb
@@ -67,7 +67,7 @@ module HistoryConcern
     history_class = self.class.history_class || histories
     history = history_class.new
     attributes.each_pair do |att_name, att_value|
-      unless ['id', 'created_at', 'updated_at'].include? att_name
+      unless ['id', 'created_at', 'updated_at', 'deleted_at'].include? att_name
         history[att_name] = att_value
       end
     end

--- a/app/models/search_base.rb
+++ b/app/models/search_base.rb
@@ -260,8 +260,33 @@ module SearchBase
     end
   end
 
+  def deleted_since(time)
+    time = parse_time(time)
+    add_filter range: {deleted_at: {gte: Site.format_date(time)}}
+    only_deleted
+  end
+
+  # Shows only deleted sites
+  def only_deleted
+    @deleted = :only_deleted
+  end
+
+  # Shows deleted and non-deleted sites
+  def show_deleted
+    @deleted = :show
+  end
+
   def get_body
     body = {}
+
+    case @deleted
+    when :only_deleted
+      add_filter exists: {field: "deleted_at"}
+    when :show
+      # Nothing
+    else
+      add_filter missing: {field: "deleted_at"}
+    end
 
     if @filters
       if @filters.length == 1

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -20,6 +20,8 @@ class Site < ActiveRecord::Base
   after_save :touch_collection_lifespan
   after_destroy :touch_collection_lifespan
 
+  acts_as_paranoid
+
   def properties
     self["properties"] ||= {}
   end

--- a/app/models/site/elasticsearch_concern.rb
+++ b/app/models/site/elasticsearch_concern.rb
@@ -5,7 +5,7 @@ module Site::ElasticsearchConcern
 
   included do
     after_save :store_in_index
-    after_destroy :remove_from_index
+    after_destroy :store_in_index
     define_model_callbacks :index
     delegate :index_name, to: :collection
   end
@@ -24,12 +24,6 @@ module Site::ElasticsearchConcern
     search = collection.new_search
     search.id id
     search.results.first
-  end
-
-  def remove_from_index
-    client = Elasticsearch::Client.new
-    client.delete index: index_name, id: id, type: 'site'
-    client.indices.refresh index: index_name
   end
 
   module ClassMethods

--- a/app/models/site/index_utils.rb
+++ b/app/models/site/index_utils.rb
@@ -98,6 +98,10 @@ module Site::IndexUtils
       version: (site.version rescue nil)
     }
 
+    if site.respond_to?(:deleted_at) && site.deleted_at
+      hash[:deleted_at] = site.deleted_at.utc.strftime(DateFormat)
+    end
+
     if site.lat && site.lng
       hash[:location] = {lat: site.lat.to_f, lon: site.lng.to_f}
       hash[:lat_analyzed] = site.lat.to_s
@@ -124,6 +128,7 @@ module Site::IndexUtils
         lng_analyzed: { type: :string },
         created_at: { type: :date, format: :basic_date_time },
         updated_at: { type: :date, format: :basic_date_time },
+        deleted_at: { type: :date, format: :basic_date_time },
         properties: { properties: fields_mapping(fields) },
         version: { type: :long }
       }

--- a/db/migrate/20160202171553_add_deleted_at_to_sites.rb
+++ b/db/migrate/20160202171553_add_deleted_at_to_sites.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToSites < ActiveRecord::Migration
+  def change
+    add_column :sites, :deleted_at, :datetime
+    add_index :sites, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151113151601) do
+ActiveRecord::Schema.define(version: 20160202171553) do
 
   create_table "activities", force: true do |t|
     t.integer  "user_id"
@@ -313,9 +313,11 @@ ActiveRecord::Schema.define(version: 20151113151601) do
     t.string   "id_with_prefix"
     t.string   "uuid"
     t.integer  "version",                                            default: 0
+    t.datetime "deleted_at"
   end
 
   add_index "sites", ["collection_id"], name: "index_sites_on_collection_id", using: :btree
+  add_index "sites", ["deleted_at"], name: "index_sites_on_deleted_at", using: :btree
 
   create_table "sites_permissions", force: true do |t|
     t.integer  "membership_id"

--- a/spec/models/site_elasticsearch_concern_spec.rb
+++ b/spec/models/site_elasticsearch_concern_spec.rb
@@ -25,13 +25,16 @@ describe Site::ElasticsearchConcern, :type => :model do
     expect(Site.parse_time(results[0]["_source"]["updated_at"]).to_i).to eq(site.updated_at.to_i)
   end
 
-  it "removes from index after destroy" do
+  it "makrs as deleted when destroyed" do
     site = collection.sites.make
     site.destroy
 
     client = Elasticsearch::Client.new
     results = client.search index: site.index_name
-    expect(results["hits"]["hits"].length).to eq(0)
+    hits = results["hits"]["hits"]
+    expect(hits.length).to eq(1)
+    deleted_at = Time.parse(hits[0]["_source"]["deleted_at"])
+    expect(deleted_at.utc.to_i).to eq(site.deleted_at.utc.to_i)
   end
 
   it "stores sites without lat and lng in index" do


### PR DESCRIPTION
When deleting a site, instead of removing it from the database and from the elasticsearch index, mark it as deleted: store the "delete_at" time in mysql and in elasticsearch.

By default, deleted sites are not returned in any point in the website. The only way to access them is via the API, using the "deleted_since" query parameter.

The [wiki](https://github.com/instedd/resourcemap/wiki/API-for-Filtering) should be modified after this PR gets merged.