### PR TITLE
Feature/telemetry accounts metric

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'mini_magick'
 gem 'activerecord-import'
 gem 'active_model_serializers'
 gem 'includes-count'
-gem 'poirot_rails', git: "https://github.com/instedd/poirot_rails.git", branch: 'master' unless ENV['CI']
+gem 'poirot_rails', git: "https://github.com/instedd/poirot_rails.git", branch: 'master' unless ENV['CI'] || (ENV['POIROT_ENABLED'] == 'false')
 gem 'instedd_telemetry', git: "https://github.com/instedd/telemetry_rails", branch: 'master'
 gem 'paranoia', '~> 2.0'
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ Start the Jasmine server with:
 And open a browser tab in [http://localhost:8888](http://localhost:8888)
 
 
+### Docker development
+
+`docker-compose.yml` file build a development environment mounting the current folder and running rails in development environment.
+
+Run the following commands to have a stable development environment.
+
+```
+$ docker-compose run --rm --no-deps web bundle install
+$ ./on-web rake db:create db:schema:load db:seed
+$ docker-compose up
+```
+
+To setup and run test, once the web container is running:
+
+```
+$ docker exec -it resourcemap_web_1 bash
+root@45ccfa697a3a:/app# RAILS_ENV=test rake db:create db:schema:load
+$ ./on-web rake
+$ ./on-web rake spec SPEC=spec/models/user_spec.rb
+```
+
 ## Deployment
 
 Resource Map uses [Capistrano 3](http://capistranorb.com) to deploy. Capistrano

--- a/app/models/telemetry/accounts_collector.rb
+++ b/app/models/telemetry/accounts_collector.rb
@@ -1,0 +1,13 @@
+module Telemetry::AccountsCollector
+
+  def self.collect_stats(period)
+    {
+      "counters" => [{
+        "metric" => "accounts",
+        "key"    => { },
+        "value"  => User.where("created_at < ?", period.end).count,
+      }]
+    }
+  end
+
+end

--- a/config/initializers/instedd_telemetry.rb
+++ b/config/initializers/instedd_telemetry.rb
@@ -16,5 +16,6 @@ InsteddTelemetry.setup do |config|
    config.add_collector Telemetry::NewCollectionsCollector
    config.add_collector Telemetry::SitesCollector
    config.add_collector Telemetry::FieldsCollector
+   config.add_collector Telemetry::AccountsCollector
 
 end

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -1,0 +1,14 @@
+version: '2.0'
+
+services:
+  rails:
+    image: instedd/nginx-rails:2.1
+    environment:
+      RAILS_ENV: development
+      ELASTICSEARCH_URL: 'elasticsearch:9200'
+      REDIS_URL: 'redis://redis:6379'
+      DATABASE_URL: 'mysql2://root@db'
+      POIROT_ENABLED: 'false'
+    volumes:
+      - .:/app
+      - bundle:/usr/local/bundle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '2.0'
+
+services:
+  db:
+    image: mysql:5.6
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - db:/var/lib/mysql
+
+  elasticsearch:
+    image: elasticsearch:1.7
+    command: elasticsearch -Des.network.host=0.0.0.0
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
+
+  redis:
+    image: redis
+
+  web:
+    extends:
+      file: docker-compose-base.yml
+      service: rails
+    command: bundle exec rails server -b 0.0.0.0
+    links:
+      - db
+      - elasticsearch
+      - redis
+    ports:
+      - 3000:3000
+
+  resque:
+    extends:
+      file: docker-compose-base.yml
+      service: rails
+    command: bundle exec rake resque:work TERM_CHILD=1 FORK_PER_JOB=false
+    links:
+      - db
+      - elasticsearch
+      - redis
+
+  resque_scheduler:
+    extends:
+      file: docker-compose-base.yml
+      service: rails
+    command: bundle exec rake resque:scheduler
+    links:
+      - db
+      - elasticsearch
+      - redis
+
+volumes:
+  db:
+  elastic:
+  redis:
+  bundle:

--- a/on-web
+++ b/on-web
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker-compose run --rm web "$@"

--- a/spec/models/telemetry/accounts_collector_spec.rb
+++ b/spec/models/telemetry/accounts_collector_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Telemetry::AccountsCollector do
+
+  it "counts accounts for current period" do
+    3.times { User.make }
+    period = InsteddTelemetry::Period.current
+
+    stats = Telemetry::AccountsCollector.collect_stats(period)
+
+    assert_equal stats, {
+      "counters" => [
+        {
+        "metric" => "accounts",
+        "key" => {},
+        "value" => 3
+        }
+      ]
+    }
+  end
+
+  it "takes into account period date" do
+    Timecop.freeze(Time.now)
+    3.times { User.make }
+    p0 = InsteddTelemetry::Period.current
+
+    Timecop.freeze(Time.now + InsteddTelemetry::Period.span)
+    2.times { User.make }
+    p1 = InsteddTelemetry::Period.current
+
+    assert_equal Telemetry::AccountsCollector.collect_stats(p0), {
+      "counters" => [{
+        "metric" => "accounts",
+        "key" => {},
+        "value" => 3
+      }]
+    }
+
+    assert_equal Telemetry::AccountsCollector.collect_stats(p1), {
+      "counters" => [{
+        "metric" => "accounts",
+        "key" => {},
+        "value" => 5
+      }]
+    }
+  end
+
+end


### PR DESCRIPTION
* adds accounts telemtry metric (ref: instedd/telemetry_rails#116)
* adds and document how to develop using a docker environment
  * `ENV['POIROT_ENABLED'] == 'false'` is needed since the base development image does not include libzmq