### PR TITLE
'Select one' fields in single-edit mode

### DIFF
--- a/app/assets/javascripts/collections/field.coffee
+++ b/app/assets/javascripts/collections/field.coffee
@@ -202,12 +202,6 @@ onCollections ->
       window.model.initDatePicker(optionsDatePicker)
       window.model.initAutocomplete()
 
-    notifyEdit: (ev) =>
-      # TODO: remove this eventually; this handler exists only to be installed
-      # as the mousedown handler for the field's row DIV. Otherwise, there are
-      # situations when clicking on the row doesn't activate the edition
-      undefined
-
     keyPress: (field, event) =>
       switch event.keyCode
         when 13 then @save()

--- a/app/views/collections/index/_map.haml
+++ b/app/views/collections/index/_map.haml
@@ -204,7 +204,7 @@
               /ko if: writeable
               /- TODO: remove the mousedown handler. Otherwise, there are
               /- situations when clicking on the row doesn't activate the edition
-              %div.site_row.writeable{ko(click: 'edit', event: {mousedown: 'notifyEdit'})}
+              %div.site_row.writeable{ko(click: 'edit')}
                 %span{ko(text: :errorMessage, validationPopover: :errorMessage), style: 'display: none;'}
                 %label.field-name{ko(text: "name + ':'", topPopover: "__('Field Code') + ': ' + code", css: { error: :error })}
                 /ko if: hasValue() && !error()


### PR DESCRIPTION
Select one fields (HTML `<select>` elements) work again after deleting an old workaround for browser misbehaviours.