### PR TITLE
Disable local accounts when Guisso is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
       - name: Set environment up
         run: |
           mv docker-compose.ci.yml docker-compose.override.yml
-          docker-compose pull
-          docker-compose up -d db elasticsearch redis
-          docker-compose run --rm --no-deps web bundle
-          docker-compose run --rm --no-deps web rake db:setup
-          docker-compose run --rm --no-deps web rake db:test:prepare
+          docker compose pull
+          docker compose up -d db elasticsearch redis
+          docker compose run --rm --no-deps web bundle
+          docker compose run --rm --no-deps web rake db:setup
+          docker compose run --rm --no-deps web rake db:test:prepare
 
       - name: Run specs
         run: |
-          docker-compose run --rm web bundle exec rspec spec/ plugins/
-          docker-compose run --rm web bundle exec rspec -t js spec/integration/
-          docker-compose run --rm web bundle exec rake jasmine:ci
+          docker compose run --rm web bundle exec rspec spec/ plugins/
+          docker compose run --rm web bundle exec rspec -t js spec/integration/
+          docker compose run --rm web bundle exec rake jasmine:ci
 
   build:
     needs: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ruby:2.3
 # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
 RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 
+RUN echo 'deb http://archive.debian.org/debian stretch main\n\
+  deb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 # Install dependencies
 RUN \
   apt-get update && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,6 +3,9 @@ FROM ruby:2.3
 # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
 RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 
+RUN echo 'deb http://archive.debian.org/debian stretch main\n\
+  deb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y libzmq3-dev nodejs && \

--- a/README.md
+++ b/README.md
@@ -121,16 +121,16 @@ And open a browser tab in [http://localhost:8888](http://localhost:8888)
 Run the following commands to have a stable development environment.
 
 ```
-$ docker-compose run --rm --no-deps web bundle install
-$ docker-compose up -d db
-$ docker-compose run --rm web rake db:setup
-$ docker-compose up
+$ docker compose run --rm --no-deps web bundle install
+$ docker compose up -d db
+$ docker compose run --rm web rake db:setup
+$ docker compose up
 ```
 
 To setup and run test, once the web container is running:
 
 ```
-$ docker-compose exec web bash
+$ docker compose exec web bash
 root@web_1 $ rake
 ```
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ ResourceMap::Application.routes.draw do
     # We define here a route inside the locale thats just saves the current locale in the session
     get 'omniauth/:provider' => 'omniauth#localized', as: :localized_omniauth
 
-    devise_for :users, skip: :omniauth_callbacks, controllers: {registrations: "registrations", sessions: 'sessions'}
+    devise_for :users, skip: [ :omniauth_callbacks, ( :registrations if Guisso.enabled? ) ], controllers: {registrations: "registrations", sessions: 'sessions'}
     guisso_for :user
 
     devise_scope :user do

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/sh -e
 
-docker-compose pull
-docker-compose up -d db elasticsearch redis
-docker-compose run --rm --no-deps web bundle
-docker-compose run --rm --no-deps web rake db:setup
-docker-compose run --rm --no-deps web rake db:test:prepare
+docker compose pull
+docker compose up -d db elasticsearch redis
+docker compose run --rm --no-deps web bundle
+docker compose run --rm --no-deps web rake db:setup
+docker compose run --rm --no-deps web rake db:test:prepare

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2.0'
 services:
   db:
     image: mysql:5.7
+    platform: linux/amd64
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     volumes:
@@ -10,12 +11,14 @@ services:
 
   elasticsearch:
     image: elasticsearch:1.7
+    platform: linux/amd64
     command: elasticsearch -Des.network.host=0.0.0.0
     volumes:
       - elastic:/usr/share/elasticsearch/data
 
   redis:
     image: redis:4.0-alpine
+    platform: linux/amd64
     volumes:
       - redis:/data
 
@@ -29,6 +32,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-dev
+    platform: linux/amd64
     environment:
       RAILS_ENV:
       ELASTICSEARCH_URL: 'elasticsearch:9200'

--- a/on-web
+++ b/on-web
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose run --rm web "$@"
+docker compose run --rm web "$@"


### PR DESCRIPTION
If we delegate authentication to Guisso, then stop using Devise's local accounts.
    
We want to have this in production, since Guisso has CAPTCHA implemented to avoid automated account creation - and we want to avoid implementing CAPTCHA on each of our apps.

Also, workaround some of the tech debth of the stack.